### PR TITLE
fix: Correção da dag smooth

### DIFF
--- a/dags/smooth.py
+++ b/dags/smooth.py
@@ -9,7 +9,7 @@ from datetime import datetime
     catchup=False,
     tags=["smooth"],
 )
-def smooth()
+def smooth():
     video = SmoothOperator(
         task_id="youtube_video"
     )


### PR DESCRIPTION
1. **Correção de sintaxe**:
   - A definição da função `smooth` foi corrigida para incluir um espaço após `def smooth()`, melhorando a legibilidade e conformidade com as práticas de codificação.